### PR TITLE
 Add tilling container and window tree

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -8,6 +8,7 @@
 # include "ServerInput.hpp"
 # include "ServerOutput.hpp"
 # include "Seat.hpp"
+# include "wm/WindowTree.hpp"
 
 class Server
 {
@@ -16,6 +17,8 @@ public:
   ~Server();
 
   void run();
+
+  wm::WindowTree windowTree;
 
   struct wl_display *display;
   struct wlr_backend *backend;

--- a/include/View.hpp
+++ b/include/View.hpp
@@ -2,6 +2,7 @@
 
 # include "Wlroots.hpp"
 # include "ServerCursor.hpp"
+# include "wm/WindowNodeIndex.hpp"
 
 class Server;
 
@@ -26,6 +27,8 @@ public:
   struct wlr_xdg_surface_v6 *xdg_surface;
   bool mapped;
   int x, y;
+  // while this is null the window is floating
+  wm::WindowNodeIndex windowNode{wm::nullNode};
 };
 
 namespace ServerView

--- a/include/View.hpp
+++ b/include/View.hpp
@@ -22,8 +22,6 @@ public:
 
   struct wl_list link;
 
-  void setListeners();
-
   Server *server;
   struct wlr_xdg_surface_v6 *xdg_surface;
   bool mapped;

--- a/include/wm/Container.hpp
+++ b/include/wm/Container.hpp
@@ -21,7 +21,7 @@ namespace wm
 
   struct Rect
   {
-    std::array<uint16_t, 2u> position;
+    std::array<int16_t, 2u> position;
     std::array<uint16_t, 2u> size;
   };
 
@@ -30,26 +30,26 @@ namespace wm
   {
   private:
     uint16_t getChildWidth(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex);
-    uint16_t updateChildWidths(WindowNodeIndex index, WindowTree &windowTree);
+    void updateChildWidths(WindowNodeIndex index, WindowTree &windowTree);
 
     /// Doesn't actually update size of windowData, only the contents of the container
     void resize_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
     /// Doesn't actually update position of windowData, only the contents of the container
-    void move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+    void move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);
   public:
     Rect rect;
 
     static constexpr bool const horizontalTiling{false};
-    static constexpr bool const verti$calTiling{!horizontalTiling};
+    static constexpr bool const verticalTiling{!horizontalTiling};
     bool direction{horizontalTiling};
     
     void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
-    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);
 
     WindowNodeIndex addChild(WindowNodeIndex index, WindowTree &windowTree, ClientData &&newChildWindowData);
     void removeChild(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex);
 
-    std::array<uint16_t, 2u> getPosition() const noexcept;
+    std::array<int16_t, 2u> getPosition() const noexcept;
     std::array<uint16_t, 2u> getSize() const noexcept;
   };
 }

--- a/include/wm/Container.hpp
+++ b/include/wm/Container.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <vector>
+#include <array>
+
+#include "wm/WindowNodeIndex.hpp"
+
+struct wl_resource;
+
+namespace wm
+{
+  class WindowTree;
+  class WindowData;
+  class ClientData;
+
+  enum class PlacementStyle
+    {
+     tilling,
+     floaty
+    };
+
+  struct Rect
+  {
+    std::array<uint16_t, 2u> position;
+    std::array<uint16_t, 2u> size;
+  };
+
+
+  struct Container
+  {
+  private:
+    uint16_t getChildWidth(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex);
+    uint16_t updateChildWidths(WindowNodeIndex index, WindowTree &windowTree);
+
+    /// Doesn't actually update size of windowData, only the contents of the container
+    void resize_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
+    /// Doesn't actually update position of windowData, only the contents of the container
+    void move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+  public:
+    Rect rect;
+
+    static constexpr bool const horizontalTiling{false};
+    static constexpr bool const verti$calTiling{!horizontalTiling};
+    bool direction{horizontalTiling};
+    
+    void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
+    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+
+    WindowNodeIndex addChild(WindowNodeIndex index, WindowTree &windowTree, ClientData &&newChildWindowData);
+    void removeChild(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex);
+
+    std::array<uint16_t, 2u> getPosition() const noexcept;
+    std::array<uint16_t, 2u> getSize() const noexcept;
+  };
+}

--- a/include/wm/WindowData.hpp
+++ b/include/wm/WindowData.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <array>
+#include <variant>
+
+#include "wm/Container.hpp"
+
+#include "View.hpp"
+
+namespace wm
+{
+  struct ClientData
+  {
+    View *view;
+
+    /// Doesn't actually update size of windowData, only the surface itself
+    void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
+    /// Doesn't actually update position of windowData, only the surface itself
+    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+    std::array<uint16_t, 2u> getPosition() const noexcept;
+    std::array<uint16_t, 2u> getSize() const noexcept;
+  };
+
+  struct WindowData
+  {
+    // Rect rect;
+    std::variant<Container, ClientData> data;
+
+    void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
+    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+
+    std::array<uint16_t, 2u> getPosition() const noexcept;
+    std::array<uint16_t, 2u> getSize() const noexcept;
+    
+  };
+};

--- a/include/wm/WindowData.hpp
+++ b/include/wm/WindowData.hpp
@@ -16,8 +16,8 @@ namespace wm
     /// Doesn't actually update size of windowData, only the surface itself
     void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
     /// Doesn't actually update position of windowData, only the surface itself
-    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
-    std::array<uint16_t, 2u> getPosition() const noexcept;
+    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);
+    std::array<int16_t, 2u> getPosition() const noexcept;
     std::array<uint16_t, 2u> getSize() const noexcept;
   };
 
@@ -27,9 +27,9 @@ namespace wm
     std::variant<Container, ClientData> data;
 
     void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
-    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position);
+    void move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);
 
-    std::array<uint16_t, 2u> getPosition() const noexcept;
+    std::array<int16_t, 2u> getPosition() const noexcept;
     std::array<uint16_t, 2u> getSize() const noexcept;
     
   };

--- a/include/wm/WindowNodeIndex.hpp
+++ b/include/wm/WindowNodeIndex.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+
+
+namespace wm
+{
+  struct WindowNodeIndex
+  {
+    /// used for offsets (operators `+=`, `+`, `-=`, `-`)
+    using offset_type = uint16_t;
+    /// the stored type
+    using data_type = uint16_t;
+
+      data_type data;
+
+    constexpr WindowNodeIndex(WindowNodeIndex const &) noexcept = default;
+    constexpr WindowNodeIndex &operator=(WindowNodeIndex const &) noexcept = default;
+
+    /// Construtor is explicit, to avoid conversion
+    explicit constexpr WindowNodeIndex(data_type data = 0u) noexcept
+      : data(data)
+    {}
+
+#define WINDOW_NODE_INDEX_PREFIX_OP(OP)			\
+    constexpr WindowNodeIndex &operator OP() noexcept	\
+    {							\
+      OP data;						\
+      return *this;					\
+    }
+
+    WINDOW_NODE_INDEX_PREFIX_OP(++);
+    WINDOW_NODE_INDEX_PREFIX_OP(--);
+
+#undef WINDOW_NODE_INDEX_PREFIX_OP
+
+#define WINDOW_NODE_INDEX_SUFFIX_OP(OP)			\
+    constexpr WindowNodeIndex operator OP(int) noexcept \
+    {							\
+      auto copy(*this);					\
+      OP *this;						\
+      return copy;					\
+    }
+
+    WINDOW_NODE_INDEX_SUFFIX_OP(++);
+    WINDOW_NODE_INDEX_SUFFIX_OP(--);
+
+#undef WINDOW_NODE_INDEX_SUFFIX_OP
+
+#define WINDOW_NODE_INDEX_COMPARE(OP)					\
+    constexpr bool operator OP(WindowNodeIndex const &other) const noexcept \
+    {                                                                   \
+      return data OP other.data;                                        \
+    }
+
+    WINDOW_NODE_INDEX_COMPARE(==);
+    WINDOW_NODE_INDEX_COMPARE(!=);
+    WINDOW_NODE_INDEX_COMPARE(<=);
+    WINDOW_NODE_INDEX_COMPARE(>=);
+    WINDOW_NODE_INDEX_COMPARE(<);
+    WINDOW_NODE_INDEX_COMPARE(>);
+
+#undef WINDOW_NODE_INDEX_COMPARE
+
+#define WINDOW_NODE_INDEX_BINARY_OP(OP)					\
+    constexpr auto operator OP(offset_type const &other) const noexcept \
+    {									\
+      return WindowNodeIndex(static_cast<data_type>(data OP other));	\
+    }
+
+    WINDOW_NODE_INDEX_BINARY_OP(+);
+    WINDOW_NODE_INDEX_BINARY_OP(-);
+
+#undef WINDOW_NODE_INDEX_BINARY_OP
+  };
+
+  static constexpr WindowNodeIndex nullNode{uint16_t(-1u)};
+}

--- a/include/wm/WindowTree.hpp
+++ b/include/wm/WindowTree.hpp
@@ -10,7 +10,6 @@ namespace wm
 {
   class WindowTree
   {
-
   private:
     struct WindowNode
     {
@@ -32,22 +31,14 @@ namespace wm
     {
       return const_cast<WindowTree &>(*this).getNode(nodeIndex);
     }
+
   public:
     WindowTree() = delete;
     WindowTree(WindowTree &&) = delete;
     WindowTree(WindowTree const &) = delete;
 
-    WindowTree(WindowData &&screen)
-      : freeList(nullNode)
-    {
-      nodes.emplace_back(WindowNode{nullNode, nullNode, nullNode, std::move(screen)});
-    }
-
-    WindowTree(WindowData const &screen)
-      : freeList(nullNode)
-    {
-      nodes.emplace_back(WindowNode{nullNode, nullNode, nullNode, screen});
-    }
+    WindowTree(WindowData &&screen);
+    WindowTree(WindowData const &screen);
 
     uint16_t getWindowCountUpperBound() const noexcept
     {
@@ -133,61 +124,12 @@ namespace wm
       return const_cast<WindowTree &>(*this).getData(nodeIndex);
     }
 
-    WindowNodeIndex allocateIndex()
-    {
-      if (freeList == nullNode)
-	{
-	  WindowNodeIndex result(static_cast<uint16_t>(nodes.size()));
+    WindowNodeIndex allocateIndex();
 
-	  nodes.emplace_back();
-	  return result;
-	}
-      else
-	{
-	  WindowNodeIndex result(freeList);
+    void removeIndex(WindowNodeIndex index) noexcept;
 
-	  freeList = getSibling(freeList);
-	  return result;
-	}
-    }
-
-    void removeIndex(WindowNodeIndex index) noexcept
-    {
-      WindowNodeIndex child(getFirstChild(getParent(index)));
-
-      if (child == index)
-	getNode(getParent(index)).firstChild = getSibling(index);
-      else
-	{
-	  while (getSibling(child) != index)
-	    child = getSibling(child);
-	  getNode(child).nextSibling = getSibling(index);
-	}
-      getNode(index).nextSibling = freeList;
-      freeList = index;
-    }
-
-    WindowNodeIndex addChild(WindowNodeIndex parent)
-    {
-      WindowNodeIndex result(allocateIndex());
-
-      getNode(result).parent = parent;
-      getNode(result).nextSibling = getFirstChild(parent);
-      getNode(result).firstChild = nullNode;
-      getNode(parent).firstChild = result;
-      return result;
-    }
-
-    WindowNodeIndex addChildAfter(WindowNodeIndex parent, WindowNodeIndex index)
-    {
-      WindowNodeIndex result(allocateIndex());
-
-      getNode(result).parent = parent;
-      getNode(result).nextSibling = getNode(index).nextSibling;
-      getNode(result).firstChild = nullNode;
-      getNode(index).nextSibling = result;
-      return result;
-    }
+    WindowNodeIndex addChild(WindowNodeIndex parent);
+    WindowNodeIndex addChildAfter(WindowNodeIndex parent, WindowNodeIndex index);
 
   };
 }

--- a/include/wm/WindowTree.hpp
+++ b/include/wm/WindowTree.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <deque>
+#include <iterator>
+
+#include "wm/WindowNodeIndex.hpp"
+#include "wm/WindowData.hpp"
+
+namespace wm
+{
+  class WindowTree
+  {
+
+  private:
+    struct WindowNode
+    {
+      WindowNodeIndex parent;
+      WindowNodeIndex firstChild;
+      WindowNodeIndex nextSibling;
+      WindowData data;
+    };
+
+    WindowNodeIndex freeList;
+    std::deque<WindowNode> nodes;
+
+    WindowNode &getNode(WindowNodeIndex nodeIndex) noexcept
+    {
+      return nodes[nodeIndex.data];
+    }
+
+    WindowNode const &getNode(WindowNodeIndex nodeIndex) const noexcept
+    {
+      return const_cast<WindowTree &>(*this).getNode(nodeIndex);
+    }
+  public:
+    WindowTree() = delete;
+    WindowTree(WindowTree &&) = delete;
+    WindowTree(WindowTree const &) = delete;
+
+    WindowTree(WindowData &&screen)
+      : freeList(nullNode)
+    {
+      nodes.emplace_back(WindowNode{nullNode, nullNode, nullNode, std::move(screen)});
+    }
+
+    WindowTree(WindowData const &screen)
+      : freeList(nullNode)
+    {
+      nodes.emplace_back(WindowNode{nullNode, nullNode, nullNode, screen});
+    }
+
+    uint16_t getWindowCountUpperBound() const noexcept
+    {
+      return static_cast<uint16_t>(nodes.size());
+    }
+
+    WindowNodeIndex getRootIndex() const noexcept
+    {
+      return WindowNodeIndex{0};
+    }
+
+    struct Iterator
+    {
+      WindowTree const *windowTree;
+      WindowNodeIndex nodeIndex;
+
+      Iterator &operator++() noexcept
+      {
+	nodeIndex = windowTree->getSibling(nodeIndex);
+	return *this;
+      }
+
+      constexpr bool operator==(Iterator const &other) const noexcept
+      {
+	return nodeIndex == other.nodeIndex && windowTree == other.windowTree;
+      }
+
+      constexpr bool operator!=(Iterator const &other) const noexcept
+      {
+	return !(*this == other);
+      }
+
+      constexpr WindowNodeIndex operator*() const noexcept
+      {
+	return nodeIndex;
+      }
+    };
+
+    WindowNodeIndex getParent(WindowNodeIndex nodeIndex) const noexcept
+    {
+      return getNode(nodeIndex).parent;
+    }
+
+    WindowNodeIndex getFirstChild(WindowNodeIndex nodeIndex) const noexcept
+    {
+      return getNode(nodeIndex).firstChild;
+    }
+
+    WindowNodeIndex getSibling(WindowNodeIndex nodeIndex) const noexcept
+    {
+      return getNode(nodeIndex).nextSibling;
+    }
+
+    struct IteratorPair
+    {
+      Iterator _begin;
+      Iterator _end;
+
+      constexpr auto begin() const noexcept
+      {
+	return _begin;
+      }
+
+      constexpr auto end() const noexcept
+      {
+	return _end;
+      }
+    };
+
+
+    IteratorPair getChildren(WindowNodeIndex nodeIndex) const noexcept
+    {
+      return {Iterator{this, getFirstChild(nodeIndex)}, Iterator{this, nullNode}};
+    }
+   
+    WindowData &getData(WindowNodeIndex nodeIndex) noexcept
+    {
+      return getNode(nodeIndex).data;
+    }
+
+    WindowData const &getData(WindowNodeIndex nodeIndex) const noexcept
+    {
+      return const_cast<WindowTree &>(*this).getData(nodeIndex);
+    }
+
+    WindowNodeIndex allocateIndex()
+    {
+      if (freeList == nullNode)
+	{
+	  WindowNodeIndex result(static_cast<uint16_t>(nodes.size()));
+
+	  nodes.emplace_back();
+	  return result;
+	}
+      else
+	{
+	  WindowNodeIndex result(freeList);
+
+	  freeList = getSibling(freeList);
+	  return result;
+	}
+    }
+
+    void removeIndex(WindowNodeIndex index) noexcept
+    {
+      WindowNodeIndex child(getFirstChild(getParent(index)));
+
+      if (child == index)
+	getNode(getParent(index)).firstChild = getSibling(index);
+      else
+	{
+	  while (getSibling(child) != index)
+	    child = getSibling(child);
+	  getNode(child).nextSibling = getSibling(index);
+	}
+      getNode(index).nextSibling = freeList;
+      freeList = index;
+    }
+
+    WindowNodeIndex addChild(WindowNodeIndex parent)
+    {
+      WindowNodeIndex result(allocateIndex());
+
+      getNode(result).parent = parent;
+      getNode(result).nextSibling = getFirstChild(parent);
+      getNode(result).firstChild = nullNode;
+      getNode(parent).firstChild = result;
+      return result;
+    }
+
+    WindowNodeIndex addChildAfter(WindowNodeIndex parent, WindowNodeIndex index)
+    {
+      WindowNodeIndex result(allocateIndex());
+
+      getNode(result).parent = parent;
+      getNode(result).nextSibling = getNode(index).nextSibling;
+      getNode(result).firstChild = nullNode;
+      getNode(index).nextSibling = result;
+      return result;
+    }
+
+  };
+}

--- a/source/Server.cpp
+++ b/source/Server.cpp
@@ -7,6 +7,7 @@
 #include "Seat.hpp"
 
 Server::Server()
+  : windowTree(wm::WindowData{wm::Container{{{{0, 0}}, {{1920, 1080}}}}})
 {
   wlr_log_init(WLR_DEBUG, NULL);
 

--- a/source/View.cpp
+++ b/source/View.cpp
@@ -8,10 +8,6 @@ View::View(Server *server, struct wlr_xdg_surface_v6 *xdg_surface) :
   x(0),
   y(0)
 {
-
-}
-
-void View::setListeners() {
   struct wlr_xdg_toplevel_v6 *toplevel = xdg_surface->toplevel;
 
   SET_LISTENER(View, ViewListeners, map, server->xdgShell->xdg_surface_map);

--- a/source/XdgShell.cpp
+++ b/source/XdgShell.cpp
@@ -1,3 +1,5 @@
+#include <cassert>
+
 #include "XdgShell.hpp"
 #include "Server.hpp"
 
@@ -46,10 +48,10 @@ void XdgShell::server_new_xdg_surface([[maybe_unused]]struct wl_listener *listen
 
   if (xdg_surface->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL)
     {
+      assert(!"not handled yet");
       return;
     }
   View *view = new View(server, xdg_surface);
 
-  view->setListeners();
   wl_list_insert(&server->views, &view->link);
 };

--- a/source/XdgShell.cpp
+++ b/source/XdgShell.cpp
@@ -2,6 +2,7 @@
 
 #include "XdgShell.hpp"
 #include "Server.hpp"
+#include "wm/Container.hpp"
 
 XdgShell::XdgShell(Server *server) : server(server) {
   xdg_shell = wlr_xdg_shell_v6_create(server->display);
@@ -13,13 +14,24 @@ void XdgShell::xdg_surface_map([[maybe_unused]]struct wl_listener *listener, [[m
 {
   View *view = wl_container_of(listener, view, map);
   view->mapped = true;
+  
   ServerView::focus_view(view, view->xdg_surface->surface);
+
+  auto rootNode(server->windowTree.getRootIndex());
+  auto &rootNodeData(server->windowTree.getData(rootNode));
+
+  view->windowNode = std::get<wm::Container>(rootNodeData.data).addChild(rootNode, server->windowTree, wm::ClientData{view});
 };
 
 void XdgShell::xdg_surface_unmap([[maybe_unused]]struct wl_listener *listener, [[maybe_unused]]void *data)
 {
   View *view = wl_container_of(listener, view, unmap);
   view->mapped = false;
+
+  auto rootNode(server->windowTree.getRootIndex());
+  auto &rootNodeData(server->windowTree.getData(rootNode));
+
+  std::get<wm::Container>(rootNodeData.data).removeChild(rootNode, server->windowTree, view->windowNode);
 };
 
 void XdgShell::xdg_surface_destroy([[maybe_unused]]struct wl_listener *listener, [[maybe_unused]]void *data)

--- a/source/wm/Container.cpp
+++ b/source/wm/Container.cpp
@@ -1,0 +1,154 @@
+#include "wm/Container.hpp"
+#include "wm/WindowTree.hpp"
+
+#include <iostream>
+                                                                                 
+/*
+** ::: ::: :::       :::     :::     :::::::::  ::::    ::: ::::::::::: ::::    :::  ::::::::  ::: ::: 
+** :+: :+: :+:       :+:   :+: :+:   :+:    :+: :+:+:   :+:     :+:     :+:+:   :+: :+:    :+: :+: :+: 
+** +:+ +:+ +:+       +:+  +:+   +:+  +:+    +:+ :+:+:+  +:+     +:+     :+:+:+  +:+ +:+        +:+ +:+ 
+** +#+ +#+ +#+  +:+  +#+ +#++:++#++: +#++:++#:  +#+ +:+ +#+     +#+     +#+ +:+ +#+ :#:        +#+ +#+ 
+** +#+ +#+ +#+ +#+#+ +#+ +#+     +#+ +#+    +#+ +#+  +#+#+#     +#+     +#+  +#+#+# +#+   +#+# +#+ +#+ 
+**          #+#+# #+#+#  #+#     #+# #+#    #+# #+#   #+#+#     #+#     #+#   #+#+# #+#    #+#         
+** ### ###   ###   ###   ###     ### ###    ### ###    #### ########### ###    ####  ########  ### ### 
+**
+** gcc's -Wconversion is disabled beyond this point, please pay careful attention to any type-conversions
+** This was done because uint16_t's operator += triggers it
+*/ 
+
+// please don't include anything below this point
+#pragma GCC diagnostic ignored "-Wconversion"
+
+namespace wm
+{
+  uint16_t Container::getChildWidth(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex)
+  {
+    auto &childData(windowTree.getData(childIndex));
+    auto sibling(windowTree.getSibling(childIndex));
+
+    if (sibling == wm::nullNode)
+      return rect.position[direction] + rect.size[direction] - childData.getPosition()[direction];
+    else
+      return (windowTree.getData(sibling)).getPosition()[direction] - childData.getPosition()[direction];
+  }
+
+  uint16_t Container::updateChildWidths(WindowNodeIndex index, WindowTree &windowTree)
+  {
+    for (auto childIndex : windowTree.getChildren(index))
+      {
+	auto &childData(windowTree.getData(childIndex));
+	auto newSize(rect.size);
+	
+	newSize[direction] = getChildWidth(index, windowTree, childIndex);
+	childData.resize(childIndex, windowTree, newSize);
+      }
+  }
+
+  void Container::move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position)
+  {
+    auto children(windowTree.getChildren(index));
+    for (auto childIndex : children)
+      {
+	auto &childData(windowTree.getData(childIndex));
+	auto newPosition(childData.getPosition());
+
+	for (size_t i(0u); i != childData.getPosition().size(); ++i)
+	  {
+	    uint16_t offset(uint16_t(position[i] - rect.position[i]));
+	    newPosition[i] += offset;
+	  }
+	childData.move(childIndex, windowTree, newPosition);
+      }
+  }
+
+  void Container::move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position)
+  {
+    move_impl(index, windowTree, position);
+    rect.position = position;
+  }
+  
+  void Container::resize_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size)
+  {
+    auto children(windowTree.getChildren(index));
+    for (auto childIndex : children)
+      {
+	auto &childData(windowTree.getData(childIndex));
+	auto position(childData.getPosition());
+
+	position[direction] -= rect.position[direction];
+	position[direction] = (position[direction] * size[direction]) / (rect.size[direction]);
+	position[direction] += rect.position[direction];
+
+	childData.move(childIndex, windowTree, position);
+      }
+  }
+
+  void Container::resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size)
+  {
+    resize_impl(index, windowTree, size);
+    rect.size = size;
+    updateChildWidths(index, windowTree);
+  }
+
+  WindowNodeIndex Container::addChild(WindowNodeIndex index, WindowTree &windowTree, ClientData &&newChildWindowData)
+  {
+    {
+      auto children{windowTree.getChildren(index)};
+      uint16_t count(0u);
+
+      for ([[maybe_unused]]auto _ : children)
+	++count;
+      {
+	std::array<uint16_t, 2u> position{rect.position};
+	std::array<uint16_t, 2u> size{rect.size};
+
+	position[direction] += rect.size[direction] / (count + 1);
+	size[direction] = (size[direction] * count) / (count + 1);
+
+	resize_impl(index, windowTree, size);
+	move_impl(index, windowTree, position);
+      }
+    }
+    {
+      auto newChild(windowTree.addChild(index));
+      auto &childData(windowTree.getData(newChild));
+
+      childData.data = newChildWindowData;
+      childData.move(newChild, windowTree, rect.position);
+
+      updateChildWidths(index, windowTree);
+      return newChild;
+    }
+  }
+
+  void Container::removeChild(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex)
+  {
+    auto removedWidth(getChildWidth(index, windowTree, childIndex));
+    auto childIndex2{windowTree.getSibling(childIndex)};
+
+    windowTree.removeIndex(childIndex);
+
+    for (; childIndex2 != wm::nullNode; childIndex2 = windowTree.getSibling(childIndex2))
+      {
+	auto &childData(windowTree.getData(childIndex2));
+	auto position(childData.getPosition());
+
+	position[direction] -= removedWidth;
+	childData.move(childIndex2, windowTree, position);
+      }
+    
+    
+    {
+      std::array<uint16_t, 2u> size{rect.size};
+
+      rect.size[direction] = size[direction] - removedWidth;
+      resize(index, windowTree, size);
+    }
+  }
+
+  std::array<uint16_t, 2u> Container::getPosition() const noexcept
+  {
+    return rect.position;
+  }
+
+}

--- a/source/wm/Container.cpp
+++ b/source/wm/Container.cpp
@@ -32,21 +32,22 @@ namespace wm
       return (windowTree.getData(sibling)).getPosition()[direction] - childData.getPosition()[direction];
   }
 
-  uint16_t Container::updateChildWidths(WindowNodeIndex index, WindowTree &windowTree)
+  void Container::updateChildWidths(WindowNodeIndex index, WindowTree &windowTree)
   {
     for (auto childIndex : windowTree.getChildren(index))
       {
 	auto &childData(windowTree.getData(childIndex));
 	auto newSize(rect.size);
-	
+
 	newSize[direction] = getChildWidth(index, windowTree, childIndex);
 	childData.resize(childIndex, windowTree, newSize);
       }
   }
 
-  void Container::move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position)
+  void Container::move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position)
   {
     auto children(windowTree.getChildren(index));
+
     for (auto childIndex : children)
       {
 	auto &childData(windowTree.getData(childIndex));
@@ -61,7 +62,7 @@ namespace wm
       }
   }
 
-  void Container::move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position)
+  void Container::move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position)
   {
     move_impl(index, windowTree, position);
     rect.position = position;
@@ -99,8 +100,8 @@ namespace wm
       for ([[maybe_unused]]auto _ : children)
 	++count;
       {
-	std::array<uint16_t, 2u> position{rect.position};
-	std::array<uint16_t, 2u> size{rect.size};
+        auto position{rect.position};
+	auto size{rect.size};
 
 	position[direction] += rect.size[direction] / (count + 1);
 	size[direction] = (size[direction] * count) / (count + 1);
@@ -139,14 +140,14 @@ namespace wm
     
     
     {
-      std::array<uint16_t, 2u> size{rect.size};
+      auto size{rect.size};
 
       rect.size[direction] = size[direction] - removedWidth;
       resize(index, windowTree, size);
     }
   }
 
-  std::array<uint16_t, 2u> Container::getPosition() const noexcept
+  std::array<int16_t, 2u> Container::getPosition() const noexcept
   {
     return rect.position;
   }

--- a/source/wm/WindowData.cpp
+++ b/source/wm/WindowData.cpp
@@ -1,0 +1,45 @@
+#include "wm/WindowData.hpp"
+
+namespace wm
+{
+  void WindowData::resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size)
+  {
+    std::visit([&](auto &data)
+	       {
+		 data.resize(index, windowTree, size);
+	       }, data);
+  }
+
+  void WindowData::move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position)
+  {
+    std::visit([&](auto &data)
+	       {
+		 data.move(index, windowTree, position);
+	       }, data);
+  }
+
+  std::array<uint16_t, 2u> WindowData::getPosition() const noexcept
+  {
+    return std::visit([](auto &data) noexcept
+		      {
+			return data.getPosition();
+		      }, data);
+  }
+
+  void ClientData::resize(WindowNodeIndex, WindowTree &, std::array<uint16_t, 2u> size)
+  {
+    wlr_xdg_toplevel_v6_set_size(view->xdg_surface, size[0], size[1]);
+  }
+
+  void ClientData::move(WindowNodeIndex, WindowTree &, std::array<uint16_t, 2u> position)
+  {
+    // todo: move xdg surface
+    view->x = position[0];
+    view->y = position[1];
+  }
+
+  std::array<uint16_t, 2u> ClientData::getPosition() const noexcept
+  {
+    return {view->x, view->y};
+  }
+}

--- a/source/wm/WindowData.cpp
+++ b/source/wm/WindowData.cpp
@@ -10,7 +10,7 @@ namespace wm
 	       }, data);
   }
 
-  void WindowData::move(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> position)
+  void WindowData::move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position)
   {
     std::visit([&](auto &data)
 	       {
@@ -18,7 +18,7 @@ namespace wm
 	       }, data);
   }
 
-  std::array<uint16_t, 2u> WindowData::getPosition() const noexcept
+  std::array<int16_t, 2u> WindowData::getPosition() const noexcept
   {
     return std::visit([](auto &data) noexcept
 		      {
@@ -31,14 +31,14 @@ namespace wm
     wlr_xdg_toplevel_v6_set_size(view->xdg_surface, size[0], size[1]);
   }
 
-  void ClientData::move(WindowNodeIndex, WindowTree &, std::array<uint16_t, 2u> position)
+  void ClientData::move(WindowNodeIndex, WindowTree &, std::array<int16_t, 2u> position)
   {
     // todo: move xdg surface
     view->x = position[0];
     view->y = position[1];
   }
 
-  std::array<uint16_t, 2u> ClientData::getPosition() const noexcept
+  std::array<int16_t, 2u> ClientData::getPosition() const noexcept
   {
     return {view->x, view->y};
   }

--- a/source/wm/WindowTree.cpp
+++ b/source/wm/WindowTree.cpp
@@ -1,0 +1,1 @@
+#include "wm/WindowTree.hpp"


### PR DESCRIPTION
Some changes still are needed:
- add the child relative to the active window
- change container and window tree handling to allow node exchange
- add shortcuts to allow to change things such as tilling direction, make a window floating etc.