### PR TITLE
Add function to add child after specific child in container

### DIFF
--- a/include/wm/Container.hpp
+++ b/include/wm/Container.hpp
@@ -29,6 +29,8 @@ namespace wm
     void resize_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
     /// Doesn't actually update position of windowData, only the contents of the container
     void move_impl(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);
+    /// Doesn't actually update position of windowData, only the contents of the container after start
+    void move_after_impl(WindowTree &windowTree, WindowNodeIndex start, std::array<int16_t, 2u> position);
   public:
     Rect rect;
 
@@ -42,6 +44,7 @@ namespace wm
     void move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);
 
     WindowNodeIndex addChild(WindowNodeIndex index, WindowTree &windowTree, ClientData &&newChildWindowData);
+    WindowNodeIndex addChild(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex prev, ClientData &&newChildWindowData);
     void removeChild(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex);
 
     std::array<int16_t, 2u> getPosition() const noexcept;

--- a/source/View.cpp
+++ b/source/View.cpp
@@ -49,10 +49,21 @@ void View::xdg_surface_map([[maybe_unused]]struct wl_listener *listener, [[maybe
 
   auto &output(server->output.getOutput(getOutput()));
   auto &windowTree(output.getWindowTree());
-  auto rootNode(windowTree.getRootIndex());
-  auto &rootNodeData(windowTree.getData(rootNode));
+  if (server->views.size() == 1 || server->views[1]->windowNode == wm::nullNode) // node: we are at least ourselves in the tree
+    {
+      auto rootNode(windowTree.getRootIndex());
+      auto &rootNodeData(windowTree.getData(rootNode));
 
-  windowNode = std::get<wm::Container>(rootNodeData.data).addChild(rootNode, windowTree, wm::ClientData{this});
+      windowNode = std::get<wm::Container>(rootNodeData.data).addChild(rootNode, windowTree, wm::ClientData{this});
+    }
+  else
+    {
+      auto prevNode(server->views[1]->windowNode);
+      auto parentNode(windowTree.getParent(prevNode));
+      auto &parentNodeData(windowTree.getData(parentNode));
+
+      windowNode = std::get<wm::Container>(parentNodeData.data).addChild(parentNode, windowTree, prevNode, wm::ClientData{this});
+    }
 };
 
 void View::xdg_surface_unmap([[maybe_unused]]struct wl_listener *listener, [[maybe_unused]]void *data)


### PR DESCRIPTION
Improves terminal open command based on this.
This should also help with the "open-below" and "open-next-to" key shortcuts. (see #22)
Also added 2 missing `std::move`s.