### PR TITLE
Added output resolution detection

### DIFF
--- a/include/Output.hpp
+++ b/include/Output.hpp
@@ -15,7 +15,7 @@ class Output : public OutputListeners
 {
 public:
 
-  Output(Server *server, struct wlr_output *wlr_output);
+  Output(Server *server, struct wlr_output *wlr_output, struct wlr_output_layout *wlr_output_layout);
   ~Output() = default;
 
   void setFrameListener();

--- a/source/Output.cpp
+++ b/source/Output.cpp
@@ -14,14 +14,15 @@
 #include "stb_image.h"
 #pragma GCC diagnostic pop
 
-Output::Output(Server *server, struct wlr_output *wlr_output) :
+Output::Output(Server *server, struct wlr_output *wlr_output, struct wlr_output_layout *wlr_output_layout) :
   server(server),
   wlr_output(wlr_output),
   fullscreen(false),
   windowTree([&]()
 	     {
-	       // todo: get output size
-	       return wm::WindowData{wm::Container{{{{0, 0}}, {{1920, 1080}}}}};
+	       auto box = wlr_output_layout_get_box(wlr_output_layout, wlr_output);
+
+	       return wm::WindowData{wm::Container{{{{box->x, box->y}}, {{box->width, box->height}}}}};
 	     }())
 {
   refreshImage();

--- a/source/ServerOutput.cpp
+++ b/source/ServerOutput.cpp
@@ -17,11 +17,12 @@ void ServerOutput::server_new_output([[maybe_unused]]struct wl_listener *listene
       wlr_output_set_mode(wlr_output, mode);
     }
 
-  std::unique_ptr<Output> output(new Output(server, wlr_output));
+  wlr_output_layout_add_auto(output_layout, wlr_output);
+
+  std::unique_ptr<Output> output(new Output(server, wlr_output, output_layout));
   output->setFrameListener();
   outputs.emplace_back(std::move(output));
 
-  wlr_output_layout_add_auto(output_layout, wlr_output);
   wlr_output_create_global(wlr_output);
 }
 


### PR DESCRIPTION
Whey is the resolution wrong when launching the compositor inside i3?
-> because i3 resizes the window which isn't supposed to happen in general. Check by putting the window into floating-mode

(We may fix this in the future)