### PR TITLE
Added open-below and open-right shortcuts

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -10,6 +10,13 @@
 # include "Seat.hpp"
 # include "conf/Configuration.hpp"
 
+enum class OpenType : uint8_t
+  {
+   dontCare = 0,
+   below,
+   right
+  };
+
 class Server
 {
 public:
@@ -46,6 +53,7 @@ public:
   double grab_x, grab_y;
   int grab_width, grab_height;
   uint32_t resize_edges;
+  OpenType openType;
 
   wl_display *getWlDisplay() const noexcept
   {

--- a/include/wm/Container.hpp
+++ b/include/wm/Container.hpp
@@ -32,11 +32,15 @@ namespace wm
     /// Doesn't actually update position of windowData, only the contents of the container after start
     void move_after_impl(WindowTree &windowTree, WindowNodeIndex start, std::array<int16_t, 2u> position);
   public:
+    Container(Rect const &rect, bool direction = horizontalTilling) noexcept;
+    Container(Container const &) = delete;
+    Container(Container &&) = default;
+
     Rect rect;
 
     static constexpr bool const horizontalTilling{false};
     static constexpr bool const verticalTilling{!horizontalTilling};
-    bool direction{horizontalTilling};
+    bool direction;
 
     void updateChildWidths(WindowNodeIndex index, WindowTree &windowTree);
 

--- a/include/wm/WindowData.hpp
+++ b/include/wm/WindowData.hpp
@@ -22,7 +22,7 @@ namespace wm
   struct WindowData
   {
     // Rect rect;
-    std::variant<Container, ClientData> data;
+    std::variant<ClientData, Container> data;
 
     void resize(WindowNodeIndex index, WindowTree &windowTree, std::array<uint16_t, 2u> size);
     void move(WindowNodeIndex index, WindowTree &windowTree, std::array<int16_t, 2u> position);

--- a/include/wm/WindowTree.hpp
+++ b/include/wm/WindowTree.hpp
@@ -38,7 +38,6 @@ namespace wm
     WindowTree(WindowTree const &) = delete;
 
     WindowTree(WindowData &&screen);
-    WindowTree(WindowData const &screen);
 
     uint16_t getWindowCountUpperBound() const noexcept
     {

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -25,8 +25,9 @@ Keyboard::Keyboard(Server *server, struct wlr_input_device *device)
   shortcuts["Alt+Escape"] = {"Leave", [server](){ Commands::close_compositor(server); }};
   shortcuts["Alt+Space"] = {"Toggle float", [server](){ Commands::toggle_float_window(server); }};
   shortcuts["Alt+E"] = {"Switch position", [server](){ Commands::switch_container_direction(server); }};
+  shortcuts["Alt+H"] = {"Open below", [server](){ server->openType = OpenType::below; }};
+  shortcuts["Alt+V"] = {"Open right", [server](){ server->openType = OpenType::right; }};
 
-  shortcuts["a+b"] = {"TEST", [](){ std::cout << "TEST SHORTCUT" << std::endl; }};
   //Allowing keyboard debug
   shortcuts["Alt+D"] = {"Debug", [this](){debug = !debug;}};
 }

--- a/source/Server.cpp
+++ b/source/Server.cpp
@@ -23,6 +23,7 @@ Server::Server()
   , cursor(this)
   , input(this)
   , seat(this)
+  , openType(OpenType::dontCare)
 {
   wlr_data_device_manager_create(getWlDisplay());
 }

--- a/source/wm/Container.cpp
+++ b/source/wm/Container.cpp
@@ -21,6 +21,12 @@
 
 namespace wm
 {
+  Container::Container(Rect const &rect, bool direction) noexcept
+    : rect(rect)
+    , direction(direction)
+  {
+  }
+
   uint16_t Container::getChildWidth(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex)
   {
     auto &childData(windowTree.getData(childIndex));
@@ -58,8 +64,7 @@ namespace wm
 
 	for (size_t i(0u); i != childData.getPosition().size(); ++i)
 	  {
-	    uint16_t offset(uint16_t(position[i] - rect.position[i]));
-	    newPosition[i] += offset;
+	    newPosition[i] += position[i] - rect.position[i];
 	  }
 	childData.move(childIndex, windowTree, newPosition);
       }
@@ -194,10 +199,11 @@ namespace wm
   {
     for (auto child : windowTree.getChildren(index))
       {
-	auto childData(windowTree.getData(child));
+	auto &childData(windowTree.getData(child));
 	auto position(childData.getPosition());
 
-	position[!direction] = (position[direction] * rect.size[!direction]) / rect.size[direction];
+	position[!direction] = ((position[direction] - rect.position[direction]) * rect.size[!direction]) / rect.size[direction]
+	  + rect.position[!direction];
 	position[direction] = rect.position[direction];
 	childData.move(child, windowTree, position);
       }

--- a/source/wm/WindowTree.cpp
+++ b/source/wm/WindowTree.cpp
@@ -8,12 +8,6 @@ namespace wm
     nodes.emplace_back(WindowNode{nullNode, nullNode, nullNode, std::move(screen)});
   }
 
-  WindowTree::WindowTree(WindowData const &screen)
-    : freeList(nullNode)
-  {
-    nodes.emplace_back(WindowNode{nullNode, nullNode, nullNode, screen});
-  }
-
   WindowNodeIndex WindowTree::allocateIndex()
   {
     if (freeList == nullNode)


### PR DESCRIPTION
Also fixed a bug when switching direction of a container containing a container.
This was due to an accidental copy of a ClientData which only works when it contains a view
(since the copy will have the same pointer and refer to the same view).
To avoid this in the future, made Container non-copiable and changed code to accommodate.

See #22 to see which sub goal this accomplishes.