### PR TITLE
Configuration: avoid resetting value if setting is not available

### DIFF
--- a/source/conf/Configuration.cpp
+++ b/source/conf/Configuration.cpp
@@ -146,6 +146,7 @@ namespace conf
 	subscriptions.at(name).hasChanged = false;
       return result;
     } catch (std::out_of_range const &) {
+      subscriptions[name].hasChanged = false;
       return true;
     }
   }


### PR DESCRIPTION
If a setting was not present, it was flagged as changed forever.