### PR TITLE
Cleanup: added helper "removeFromParent", fixed bugs, removed dump()

### DIFF
--- a/include/wm/Container.hpp
+++ b/include/wm/Container.hpp
@@ -58,5 +58,8 @@ namespace wm
     std::array<FixedPoint<-4, int32_t>, 2u> getPosition() const noexcept;
     std::array<uint16_t, 2u> getSize() const noexcept;
     std::array<FixedPoint<-4, int32_t>, 2u> getMinSize(WindowNodeIndex index, WindowTree &windowTree) const noexcept;
+
+    static void removeFromParent(WindowTree &windowTree, WindowNodeIndex index);
+    static void removeFromParent(WindowTree &windowTree, WindowNodeIndex index, WindowNodeIndex parent);
   };
 }

--- a/source/Commands.cpp
+++ b/source/Commands.cpp
@@ -102,12 +102,10 @@ namespace Commands
     if (XdgView *view = server.getFocusedView())
       {
 	auto &windowTree(server.getActiveWindowTree());
-	auto rootNode(windowTree.getRootIndex());
-	auto &rootNodeData(windowTree.getData(rootNode));
 
 	if (view->windowNode != wm::nullNode)
 	  {
-	    rootNodeData.getContainer().removeChild(rootNode, windowTree, view->windowNode);
+	    wm::Container::removeFromParent(windowTree, view->windowNode);
 	    view->x = 10_FP;
 	    view->y = 10_FP;
 	    if (wlr_surface_is_xdg_surface_v6(view->surface))
@@ -120,6 +118,9 @@ namespace Commands
 	  }
 	else
 	  {
+	    auto rootNode(windowTree.getRootIndex());
+	    auto &rootNodeData(windowTree.getData(rootNode));
+
 	    view->windowNode = rootNodeData.getContainer().addChild(rootNode, windowTree, wm::ClientData{view});
 	    view->set_tiled(~0u);
 	  }
@@ -253,10 +254,9 @@ namespace Commands
       std::unique_ptr<XdgView> newView;
     
       {
-        auto &windowTree = currentWorkspace->get()->getWindowTree();
-        auto rootNode(windowTree.getRootIndex());
-        auto &rootNodeData(windowTree.getData(rootNode));
-        rootNodeData.getContainer().removeChild(rootNode, windowTree, view->windowNode);
+	auto &windowTree = currentWorkspace->get()->getWindowTree();
+
+	wm::Container::removeFromParent(windowTree, view->windowNode);
 	newView = std::move(view);
         currentWorkspace->get()->getViews().erase(std::find(currentWorkspace->get()->getViews().begin(), currentWorkspace->get()->getViews().end(), view));
       }
@@ -266,7 +266,7 @@ namespace Commands
         auto &rootNodeData(windowTree.getData(rootNode));
         
         newView->windowNode = rootNodeData.getContainer().addChild(rootNode, windowTree, wm::ClientData{newView.get()});
-        view->set_tiled(~0u);
+        newView->set_tiled(~0u);
         nextWorkspace->get()->getViews().emplace_back(std::move(newView));
       }
       server.outputManager.setActiveWorkspace(nextWorkspace->get());

--- a/source/WindowCommands.cpp
+++ b/source/WindowCommands.cpp
@@ -190,7 +190,6 @@ namespace Commands
 	  auto *container(&windowTree.getData(containerNode).getContainer());
 	  wm::WindowNodeIndex newViewNode;
 
-	  windowTree.dump();
 	  if (container->direction ^ moveVertical)
 	    {
 	      if (containerNode == windowTree.getRootIndex())
@@ -260,7 +259,6 @@ namespace Commands
 	      std::get<wm::ClientData>(windowTree.getData(viewNode).data)->windowNode = viewNode;
 	    } catch (...) {}
 	  windowTree.exchangeChildren(viewNode, newViewNode);
-	  windowTree.dump();
 	}
     }
   }

--- a/source/XdgView.cpp
+++ b/source/XdgView.cpp
@@ -172,11 +172,7 @@ void XdgView::xdg_surface_unmap(wl_listener *listener, void *data)
   if (windowNode == wm::nullNode)
     return;
 
-  auto &windowTree(Server::getInstance().outputManager.getActiveWorkspace()->getWindowTree());
-  auto parentNode(windowTree.getParent(windowNode));
-  auto &parentNodeData(windowTree.getData(parentNode));
-
-  parentNodeData.getContainer().removeChild(parentNode, windowTree, windowNode);
+  wm::Container::removeFromParent(workspace->getWindowTree(), windowNode);
 };
 
 template<SurfaceType surfaceType>

--- a/source/wm/Container.cpp
+++ b/source/wm/Container.cpp
@@ -1,6 +1,8 @@
 #include "wm/Container.hpp"
 #include "wm/WindowTree.hpp"
 
+#include <cassert>
+
 /*
 ** ::: ::: :::       :::     :::     :::::::::  ::::    ::: ::::::::::: ::::    :::  ::::::::  ::: :::
 ** :+: :+: :+:       :+:   :+: :+:   :+:    :+: :+:+:   :+:     :+:     :+:+:   :+: :+:    :+: :+: :+:
@@ -180,6 +182,9 @@ namespace wm
 
   void Container::removeChild(WindowNodeIndex index, WindowTree &windowTree, WindowNodeIndex childIndex)
   {
+    assert(&windowTree.getData(index).getContainer() == this || !"index must point to this container");
+    assert(windowTree.getParent(childIndex) == index || !"childIndex must be a child of the current Container");
+
     auto removedWidth(getChildWidth(index, windowTree, childIndex));
     auto childIndex2{windowTree.getSibling(childIndex)};
 
@@ -254,5 +259,13 @@ namespace wm
     return result;
   }
 
+  void Container::removeFromParent(WindowTree &windowTree, WindowNodeIndex index, WindowNodeIndex parent)
+  {
+    windowTree.getData(parent).getContainer().removeChild(parent, windowTree, index);
+  }
 
+  void Container::removeFromParent(WindowTree &windowTree, WindowNodeIndex index)
+  {
+    removeFromParent(windowTree, index, windowTree.getParent(index));
+  }
 }


### PR DESCRIPTION
- added helper removeFromParent
- used this helper in various places and fixed some bugs by doing so
- removed dump in WindowCommands which caused output clutter

Fixes #124 