### PR TITLE
Add layer shell exclusive zone and layout handling

### DIFF
--- a/include/Output.hpp
+++ b/include/Output.hpp
@@ -53,5 +53,5 @@ private:
 private:
   void output_frame(wl_listener *listener, void *data);
   void refreshImage();
-  
+  void calculateMargins(std::array<FixedPoint<-4, int>, 2> &offset, std::array<uint16_t, 2> &size);  
 };

--- a/include/Output.hpp
+++ b/include/Output.hpp
@@ -53,5 +53,5 @@ private:
 private:
   void output_frame(wl_listener *listener, void *data);
   void refreshImage();
-  void calculateMargins(std::array<FixedPoint<-4, int>, 2> &offset, std::array<uint16_t, 2> &size);  
+  void calculateMargins(std::array<uint16_t, 2> &offset, std::array<uint16_t, 2> &size);  
 };

--- a/include/util/FixedPoint.hpp
+++ b/include/util/FixedPoint.hpp
@@ -153,10 +153,24 @@ public:
   }
 
 #define FIXEDPOINT_RELTATIVE_OP(OP)					\
-  template<class OtherType>						\
-  constexpr bool operator OP (FixedPoint<exponent, OtherType> const &other) const noexcept \
+  template<int otherExponent, class OtherType>				\
+  constexpr bool operator OP (FixedPoint<otherExponent, OtherType> const &other) const noexcept \
   {									\
-    return value OP other.value;					\
+    if constexpr (otherExponent == exponent)				\
+      return value OP other.value;					\
+    else if constexpr (exponent > otherExponent)			\
+      {									\
+	if (value != (other.value >> (exponent - otherExponent)))	\
+	  return value OP (other.value >> (exponent - otherExponent));	\
+	return (value << (exponent - otherExponent)) OP other.value;	\
+      }									\
+    else								\
+      {									\
+	static_assert(otherExponent > exponent);			\
+	if ((value >> (otherExponent - exponent)) != other.value)	\
+	  return (value >> (otherExponent - exponent)) OP other.value;	\
+	return value OP (other.value << (otherExponent - exponent));	\
+}									\
   }
 
   FIXEDPOINT_RELTATIVE_OP(==);

--- a/source/OutputManager.cpp
+++ b/source/OutputManager.cpp
@@ -57,10 +57,10 @@ void OutputManager::render_surface(wlr_surface *surface, int sx, int sy, void *d
     }
 
   wlr_box box = {
-			.x = int(ox * output->scale),
-			.y = int(oy * output->scale),
-			.width = int(float(surface->current.width) * output->scale),
-			.height = int(float(surface->current.height) * output->scale),
+		 .x = int(ox * output->scale),
+		 .y = int(oy * output->scale),
+		 .width = int(float(surface->current.width) * output->scale),
+		 .height = int(float(surface->current.height) * output->scale),
   };
 
   float matrix[9];


### PR DESCRIPTION
Handles anchors being opposite, margins.
One problem remains: when exclusive layer surfaces take all the screen space, the `windowTree` is resized to an improper number causing division by zero or broken behaviour.
I had to add smarter compare operators for `FixedPoint` so that the code remained readable.
The new compare operators are probably slightly slower when the exponent mismatches (potential branching).