### PR TITLE
Added `getBool` to `conf::Configuration`, added "enable enter on hover" setting

### DIFF
--- a/include/conf/Configuration.hpp
+++ b/include/conf/Configuration.hpp
@@ -30,6 +30,9 @@ namespace conf
     /// get a setting, optimal called periodicly
     char const *get(char const *name);
 
+    /// wrapper over get to check a boolean setting
+    bool getBool(char const *name);
+
     /// get a setting only once, optimal when called rarely
     std::string getOnce(char const *name);
 

--- a/source/ServerCursor.cpp
+++ b/source/ServerCursor.cpp
@@ -184,6 +184,11 @@ void ServerCursor::process_cursor_motion(uint32_t time)
 	      {
 		wlr_seat_pointer_notify_motion(seat, time, sx, sy);
 	      }
+	    else if (Server::getInstance().configuration.getBool("enable enter on hover"))
+	      {
+		if (View *view = View::view_at(cursor->x, cursor->y, &surface, &sx, &sy))
+		  view->focus_view();
+	      }
 	  }
 	else
 	  {

--- a/source/XdgView.cpp
+++ b/source/XdgView.cpp
@@ -99,12 +99,8 @@ void XdgView::xdg_surface_map(wl_listener *listener, void *data)
 
   auto &windowTree(server.getActiveWindowTree());
 
-  if (server.openType == OpenType::dontCare)
-    {
-      char const *tiling = server.configuration.get("tiling");
-      // tiling is either 'on' or 'off'
-      server.openType = (strcmp(tiling, "off") == 0) ? OpenType::floating : OpenType::dontCare;
-    }
+  if (server.openType == OpenType::dontCare && server.configuration.getBool("enable default floating"))
+    server.openType = OpenType::floating;
   if (server.openType != OpenType::floating &&
       (server.getViews().size() == 1 || server.getViews()[1]->windowNode == wm::nullNode)) // node: we are at least ourselves in the tree
     {

--- a/source/conf/Configuration.cpp
+++ b/source/conf/Configuration.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <iostream>
 #include <vector>
+#include <cstring>
 
 namespace conf
 {
@@ -123,6 +124,15 @@ namespace conf
 	subscription.value = "";
       return subscription.value.c_str();
     }
+  }
+
+  bool Configuration::getBool(char const *name)
+  {
+    if (char const *value = get(name))
+      {
+	return (!std::strcmp(value, "yes") || !std::strcmp(value, "on") || !std::strcmp(value, "1") || !std::strcmp(value, "true"));
+      }
+    return false;
   }
 
   std::string Configuration::getOnce(char const *name)


### PR DESCRIPTION
The new `getBool` is a simple wrapper to normalise what values we accept for settings until we get an albinos API update.
I updated the "tiling" parameter to "enable default floating" (so it's positive, not a disable).
I added the "enable enter on hover" setting (which I personally prefer to have on).

Closes #137