### PR TITLE
QOL updates + made switch to fullscreen work, and switch workspace work

### DIFF
--- a/include/wm/Container.hpp
+++ b/include/wm/Container.hpp
@@ -59,7 +59,7 @@ namespace wm
     std::array<uint16_t, 2u> getSize() const noexcept;
     std::array<FixedPoint<-4, int32_t>, 2u> getMinSize(WindowNodeIndex index, WindowTree &windowTree) const noexcept;
 
-    static void removeFromParent(WindowTree &windowTree, WindowNodeIndex index);
-    static void removeFromParent(WindowTree &windowTree, WindowNodeIndex index, WindowNodeIndex parent);
+    static void removeFromParent(WindowTree &windowTree, WindowNodeIndex &index);
+    static void removeFromParent(WindowTree &windowTree, WindowNodeIndex &index, WindowNodeIndex parent);
   };
 }

--- a/include/wm/WindowTree.hpp
+++ b/include/wm/WindowTree.hpp
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <iterator>
+#include <cassert>
 
 #include "wm/WindowNodeIndex.hpp"
 #include "wm/WindowData.hpp"
@@ -24,6 +25,7 @@ namespace wm
 
     WindowNode &getNode(WindowNodeIndex nodeIndex) noexcept
     {
+      assert(nodeIndex != nullNode);
       return nodes[nodeIndex.data];
     }
 
@@ -138,7 +140,8 @@ namespace wm
 
     WindowNodeIndex allocateIndex();
 
-    void removeIndex(WindowNodeIndex index) noexcept;
+    // sets index to null node so that you don't forget to :)
+    void removeIndex(WindowNodeIndex &index) noexcept;
 
     WindowNodeIndex addChild(WindowNodeIndex parent);
     WindowNodeIndex addChildAfter(WindowNodeIndex parent, WindowNodeIndex index);

--- a/source/Commands.cpp
+++ b/source/Commands.cpp
@@ -260,22 +260,26 @@ namespace Commands
       auto &view = currentWorkspace->get()->getViews().front();
 
       std::unique_ptr<XdgView> newView;
-    
       {
-	auto &windowTree = currentWorkspace->get()->getWindowTree();
+	if (view->windowNode != wm::nullNode) {
+	  auto &windowTree = currentWorkspace->get()->getWindowTree();
 
-	wm::Container::removeFromParent(windowTree, view->windowNode);
+	  wm::Container::removeFromParent(windowTree, view->windowNode);
+	}
 	newView = std::move(view);
         currentWorkspace->get()->getViews().erase(std::find(currentWorkspace->get()->getViews().begin(), currentWorkspace->get()->getViews().end(), view));
       }
       {
         auto &windowTree = nextWorkspace->get()->getWindowTree();
         auto rootNode(windowTree.getRootIndex());
-        auto &rootNodeData(windowTree.getData(rootNode));
+	{
+	  auto &rootNodeData(windowTree.getData(rootNode));
         
-        newView->windowNode = rootNodeData.getContainer().addChild(rootNode, windowTree, wm::ClientData{newView.get()});
+	  newView->windowNode = rootNodeData.getContainer().addChild(rootNode, windowTree, wm::ClientData{newView.get()});
+	}
         newView->set_tiled(~0u);
-        nextWorkspace->get()->getViews().emplace_back(std::move(newView));
+	newView->workspace = nextWorkspace->get();
+	nextWorkspace->get()->getViews().emplace_back(std::move(newView));
       }
       server.outputManager.setActiveWorkspace(nextWorkspace->get());
     }

--- a/source/wm/Container.cpp
+++ b/source/wm/Container.cpp
@@ -259,12 +259,12 @@ namespace wm
     return result;
   }
 
-  void Container::removeFromParent(WindowTree &windowTree, WindowNodeIndex index, WindowNodeIndex parent)
+  void Container::removeFromParent(WindowTree &windowTree, WindowNodeIndex &index, WindowNodeIndex parent)
   {
     windowTree.getData(parent).getContainer().removeChild(parent, windowTree, index);
   }
 
-  void Container::removeFromParent(WindowTree &windowTree, WindowNodeIndex index)
+  void Container::removeFromParent(WindowTree &windowTree, WindowNodeIndex &index)
   {
     removeFromParent(windowTree, index, windowTree.getParent(index));
   }

--- a/source/wm/WindowTree.cpp
+++ b/source/wm/WindowTree.cpp
@@ -27,7 +27,7 @@ namespace wm
       }
   }
 
-  void WindowTree::removeIndex(WindowNodeIndex index) noexcept
+  void WindowTree::removeIndex(WindowNodeIndex &index) noexcept
   {
     WindowNodeIndex child(getFirstChild(getParent(index)));
 
@@ -41,6 +41,7 @@ namespace wm
       }
     getNode(index).nextSibling = freeList;
     freeList = index;
+    index = nullNode;
   }
 
   WindowNodeIndex WindowTree::addChild(WindowNodeIndex parent)


### PR DESCRIPTION
* Changed windowTree.removeIndex to be more user-friendly and update removeFromParent to take advantage of that.
* Fixed switch workspace to the right by correclty updating workspace pointer, and not trying to remove window from window tree when it's fullscreen.
* Indirectly included riamon's change that puts fullscreen windows in a new workspace