### PR TITLE
Fullscreen in seperate workspace (+change offset handling)

### DIFF
--- a/include/Commands.hpp
+++ b/include/Commands.hpp
@@ -57,6 +57,6 @@ namespace Commands
   void move_window_down();
   void switch_workspace(int direction);
   void new_workspace(bool create_fullscreen);
-  void close_workspace();
+  void close_workspace(Workspace *workspace);
   void close_view();
 }

--- a/source/Commands.cpp
+++ b/source/Commands.cpp
@@ -252,6 +252,8 @@ namespace Commands
                             [](auto &w) noexcept {
                               return w.get() == Server::getInstance().outputManager.getActiveWorkspace();
                             });
+      if (currentWorkspace == output->getWorkspaces().end())
+	continue;
       if (direction == Workspace::RIGHT ?
           currentWorkspace == output->getWorkspaces().end() - 1 :
           currentWorkspace == output->getWorkspaces().begin())
@@ -274,7 +276,7 @@ namespace Commands
         auto rootNode(windowTree.getRootIndex());
 	{
 	  auto &rootNodeData(windowTree.getData(rootNode));
-        
+
 	  newView->windowNode = rootNodeData.getContainer().addChild(rootNode, windowTree, wm::ClientData{newView.get()});
 	}
         newView->set_tiled(~0u);
@@ -282,6 +284,7 @@ namespace Commands
 	nextWorkspace->get()->getViews().emplace_back(std::move(newView));
       }
       server.outputManager.setActiveWorkspace(nextWorkspace->get());
+      return;
     }
   }
 

--- a/source/Commands.cpp
+++ b/source/Commands.cpp
@@ -305,17 +305,19 @@ namespace Commands
       }
   }
 
-  void close_workspace()
+  void close_workspace(Workspace *workspace)
   {
     Server &server = Server::getInstance();
 
     if (server.outputManager.workspaceCount == 2)
       return ;
+    if (!workspace)
+      workspace = Server::getInstance().outputManager.getActiveWorkspace();
     for (auto const &output : server.outputManager.getOutputs())
     {
       auto it = std::find_if(output->getWorkspaces().begin(), output->getWorkspaces().end(),
-                            [](auto &w) noexcept {
-                              return w.get() == Server::getInstance().outputManager.getActiveWorkspace();
+                            [workspace](auto &w) noexcept {
+                              return w.get() == workspace;
                             });
       auto newActiveWorkspace = it + (it ==  output->getWorkspaces().begin() ? 1 : -1);
       server.outputManager.setActiveWorkspace(newActiveWorkspace->get());

--- a/source/Keyboard.cpp
+++ b/source/Keyboard.cpp
@@ -40,7 +40,7 @@ Keyboard::Keyboard(wlr_input_device *device)
   shortcuts["Shift+Right"] = {"Switch window to right workspace", [](void*){ Commands::switch_window_from_workspace(Workspace::RIGHT); }};
   shortcuts["Shift+Left"] = {"Switch window to left workspace", [](void*){ Commands::switch_window_from_workspace(Workspace::LEFT); }};
   shortcuts["Ctrl+Alt+w"] = {"New workspace", [](void*){ Commands::new_workspace(false); }};
-  shortcuts["Ctrl+W"] = {"Close workspace", [](void*){ Commands::close_workspace(); }};
+  shortcuts["Ctrl+W"] = {"Close workspace", [](void*){ Commands::close_workspace(nullptr); }};
   shortcuts["Alt+J"] = {"Move window left", [](void *){ Commands::move_window_left(); }};
   shortcuts["Alt+L"] = {"Move window right", [](void *){ Commands::move_window_right(); }};
   shortcuts["Alt+I"] = {"Move window up", [](void *){ Commands::move_window_up(); }};

--- a/source/OutputManager.cpp
+++ b/source/OutputManager.cpp
@@ -52,8 +52,17 @@ void OutputManager::render_surface(wlr_surface *surface, int sx, int sy, void *d
   oy += sy;
   if (!rdata->fullscreen)
     {
+      wlr_box viewBox[1];
+
+      if (wlr_surface_is_xdg_surface_v6(surface))
+	wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), viewBox);
+      else if (wlr_surface_is_xdg_surface(surface))
+	wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), viewBox);
+
       ox += view->x.getDoubleValue();
+      ox -= viewBox->x;
       oy += view->y.getDoubleValue();
+      oy -= viewBox->y;
     }
 
   wlr_box box = {

--- a/source/View.cpp
+++ b/source/View.cpp
@@ -18,8 +18,15 @@ View::~View() noexcept = default;
 
 bool View::at(double lx, double ly, wlr_surface **out_surface, double *sx, double *sy)
 {
-  double view_sx = lx - x.getDoubleValue();
-  double view_sy = ly - y.getDoubleValue();
+  wlr_box viewBox[1];
+
+  if (wlr_surface_is_xdg_surface_v6(surface))
+    wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), viewBox);
+  else if (wlr_surface_is_xdg_surface(surface))
+    wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), viewBox);
+
+  double view_sx = lx - x.getDoubleValue() + viewBox->x;
+  double view_sy = ly - y.getDoubleValue() + viewBox->y;
 
   double _sx, _sy;
   wlr_surface *_surface = nullptr;

--- a/source/XdgView.cpp
+++ b/source/XdgView.cpp
@@ -218,7 +218,7 @@ void XdgView::xdg_toplevel_request_fullscreen(wl_listener *listener, void *data)
 	}
       else
 	{
-	  if constexpr (surfaceType == SurfaceType::xdg_v6)
+    if constexpr (surfaceType == SurfaceType::xdg_v6)
 	    {
 	      wlr_xdg_surface_v6 *xdg_surface = wlr_xdg_surface_v6_from_wlr_surface(surface);
 
@@ -234,6 +234,10 @@ void XdgView::xdg_toplevel_request_fullscreen(wl_listener *listener, void *data)
 	    }
 	  workspace->setFullscreenView(nullptr);
 	  fullscreen = false;
+   
+    Workspace *w = Server::getInstance().outputManager.getActiveWorkspace();
+    Commands::switch_window_from_workspace(Workspace::LEFT);
+    Commands::close_workspace(w);
 	}
     }
 }

--- a/source/XdgView.cpp
+++ b/source/XdgView.cpp
@@ -193,8 +193,8 @@ void XdgView::xdg_toplevel_request_fullscreen(wl_listener *listener, void *data)
       if (!workspace->getFullscreenView())
 	{
 	  wlr_box *outputBox = wlr_output_layout_get_box(server.outputManager.getLayout(), getWlrOutput());
-    Commands::new_workspace(true);
-    Commands::switch_window_from_workspace(Workspace::RIGHT);
+	  Commands::new_workspace(true);
+	  Commands::switch_window_from_workspace(Workspace::RIGHT);
 
 	  if constexpr (surfaceType == SurfaceType::xdg_v6)
 	    {
@@ -218,7 +218,7 @@ void XdgView::xdg_toplevel_request_fullscreen(wl_listener *listener, void *data)
 	}
       else
 	{
-    if constexpr (surfaceType == SurfaceType::xdg_v6)
+	  if constexpr (surfaceType == SurfaceType::xdg_v6)
 	    {
 	      wlr_xdg_surface_v6 *xdg_surface = wlr_xdg_surface_v6_from_wlr_surface(surface);
 
@@ -235,9 +235,10 @@ void XdgView::xdg_toplevel_request_fullscreen(wl_listener *listener, void *data)
 	  workspace->setFullscreenView(nullptr);
 	  fullscreen = false;
    
-    Workspace *w = Server::getInstance().outputManager.getActiveWorkspace();
-    Commands::switch_window_from_workspace(Workspace::LEFT);
-    Commands::close_workspace(w);
+	  set_tiled(~0u);
+	  Workspace *w = Server::getInstance().outputManager.getActiveWorkspace();
+	  Commands::switch_window_from_workspace(Workspace::LEFT);
+	  Commands::close_workspace(w);
 	}
     }
 }
@@ -349,30 +350,14 @@ void XdgView::move(wm::WindowNodeIndex, wm::WindowTree &, std::array<FixedPoint<
 
 void XdgView::move(std::array<FixedPoint<-4, int32_t>, 2u> position)
 {
-  wlr_box box[1];
-
-  if (wlr_surface_is_xdg_surface_v6(surface))
-    wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), box);
-  else if (wlr_surface_is_xdg_surface(surface))
-    wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), box);
-
-  (x = position[0]) -= FixedPoint<0, int32_t>(box->x);
-  (y = position[1]) -= FixedPoint<0, int32_t>(box->y);
+  x = position[0];
+  y = position[1];
 }
 
 std::array<FixedPoint<-4, int32_t>, 2u> XdgView::getPosition() const noexcept
 {
-  wlr_box box[1];
-
-  if (wlr_surface_is_xdg_surface_v6(surface))
-    wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), box);
-  else if (wlr_surface_is_xdg_surface(surface))
-    wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), box);
-
   std::array<FixedPoint<-4, int32_t>, 2u> result{{x, y}};
 
-  result[0] += FixedPoint<0, int32_t>(box->x);
-  result[1] += FixedPoint<0, int32_t>(box->y);
   return result;
 }
 

--- a/source/XdgView.cpp
+++ b/source/XdgView.cpp
@@ -193,7 +193,9 @@ void XdgView::xdg_toplevel_request_fullscreen(wl_listener *listener, void *data)
       if (!workspace->getFullscreenView())
 	{
 	  wlr_box *outputBox = wlr_output_layout_get_box(server.outputManager.getLayout(), getWlrOutput());
-  
+    Commands::new_workspace(true);
+    Commands::switch_window_from_workspace(Workspace::RIGHT);
+
 	  if constexpr (surfaceType == SurfaceType::xdg_v6)
 	    {
 	      wlr_xdg_surface_v6 *xdg_surface = wlr_xdg_surface_v6_from_wlr_surface(surface);


### PR DESCRIPTION
- fullscreen views now go in their own workspace
- changed offset handling to be done in rendering and in `View::at` instead of stored in the `View::{x,y}` fields
- fixed fullscreen handling to not break on mulitple outputs