### PR TITLE
Chenge offset handling

### DIFF
--- a/source/Commands.cpp
+++ b/source/Commands.cpp
@@ -114,8 +114,8 @@ namespace Commands
 	if (view->windowNode != wm::nullNode)
 	  {
 	    wm::Container::removeFromParent(windowTree, view->windowNode);
-	    view->x = 10_FP;
-	    view->y = 10_FP;
+	    view->x = 100_FP;
+	    view->y = 100_FP;
 	    if (wlr_surface_is_xdg_surface_v6(view->surface))
 	      wlr_xdg_toplevel_v6_set_size(wlr_xdg_surface_v6_from_wlr_surface(view->surface), view->previous_size[0], view->previous_size[1]);
 	    else if (wlr_surface_is_xdg_surface(view->surface))
@@ -252,6 +252,8 @@ namespace Commands
                             [](auto &w) noexcept {
                               return w.get() == Server::getInstance().outputManager.getActiveWorkspace();
                             });
+      if (currentWorkspace == output->getWorkspaces().end())
+	continue;
       if (direction == Workspace::RIGHT ?
           currentWorkspace == output->getWorkspaces().end() - 1 :
           currentWorkspace == output->getWorkspaces().begin())
@@ -274,7 +276,7 @@ namespace Commands
         auto rootNode(windowTree.getRootIndex());
 	{
 	  auto &rootNodeData(windowTree.getData(rootNode));
-        
+
 	  newView->windowNode = rootNodeData.getContainer().addChild(rootNode, windowTree, wm::ClientData{newView.get()});
 	}
         newView->set_tiled(~0u);
@@ -282,6 +284,7 @@ namespace Commands
 	nextWorkspace->get()->getViews().emplace_back(std::move(newView));
       }
       server.outputManager.setActiveWorkspace(nextWorkspace->get());
+      return;
     }
   }
 

--- a/source/Output.cpp
+++ b/source/Output.cpp
@@ -87,7 +87,7 @@ namespace
     if (FixedPoint<0, int> minPos(offset[direction] + (direction ? margin.top : margin.left));
 	(anchor & anchorDir) || (direction ? layerSurface.y : layerSurface.x) < minPos)
       {
-	(direction ? layerSurface.y : layerSurface.x) = minPos;
+        (direction ? layerSurface.y : layerSurface.x) = minPos;
 	if (anchor & oppositeDir)
 	  {
 	    outSize = size[direction] - (direction ? margin.top + margin.bottom : margin.right + margin.left);

--- a/source/OutputManager.cpp
+++ b/source/OutputManager.cpp
@@ -54,10 +54,10 @@ void OutputManager::render_surface(wlr_surface *surface, int sx, int sy, void *d
     {
       wlr_box viewBox[1];
 
-      if (wlr_surface_is_xdg_surface_v6(surface))
-      	wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), viewBox);
-      else if (wlr_surface_is_xdg_surface(surface))
-      	wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), viewBox);
+      if (wlr_surface_is_xdg_surface_v6(view->surface))
+      	wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(view->surface), viewBox);
+      else if (wlr_surface_is_xdg_surface(view->surface))
+	wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(view->surface), viewBox);
       else // if (wlr_surface_is_layer_surface(surface))
 	{
 	  viewBox->x = 0;

--- a/source/OutputManager.cpp
+++ b/source/OutputManager.cpp
@@ -52,8 +52,24 @@ void OutputManager::render_surface(wlr_surface *surface, int sx, int sy, void *d
   oy += sy;
   if (!rdata->fullscreen)
     {
+      wlr_box viewBox[1];
+
+      if (wlr_surface_is_xdg_surface_v6(surface))
+      	wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), viewBox);
+      else if (wlr_surface_is_xdg_surface(surface))
+      	wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), viewBox);
+      else // if (wlr_surface_is_layer_surface(surface))
+	{
+	  viewBox->x = 0;
+	  viewBox->y = 0;
+	}
+      
+	
+
       ox += view->x.getDoubleValue();
+      ox -= viewBox->x;
       oy += view->y.getDoubleValue();
+      oy -= viewBox->x;
     }
 
   wlr_box box = {

--- a/source/View.cpp
+++ b/source/View.cpp
@@ -18,8 +18,15 @@ View::~View() noexcept = default;
 
 bool View::at(double lx, double ly, wlr_surface **out_surface, double *sx, double *sy)
 {
-  double view_sx = lx - x.getDoubleValue();
-  double view_sy = ly - y.getDoubleValue();
+  wlr_box viewBox[1];
+
+  if (wlr_surface_is_xdg_surface_v6(surface))
+    wlr_xdg_surface_v6_get_geometry(wlr_xdg_surface_v6_from_wlr_surface(surface), viewBox);
+  else if (wlr_surface_is_xdg_surface(surface))
+    wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(surface), viewBox);
+
+  double view_sx = lx - x.getDoubleValue() + viewBox->x;
+  double view_sy = ly - y.getDoubleValue() + viewBox->y;
 
   double _sx, _sy;
   wlr_surface *_surface = nullptr;


### PR DESCRIPTION
- changed offset handling to be done in rendering and in `View::at` instead of stored in the `View::{x,y}` fields
- fixed fullscreen handling to not break on mulitple outputs
- fixed fullscreen handling now being able to cope with multiple fullscreen requests